### PR TITLE
Update Oct. 17, 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,5 @@ Update Oct. 17, 2024
 * Removed buttons to adjust battery charging voltage settings in Blynk app. This feature seems dangerous and can accidentally set the charging voltage too high because of the terrible input lag. It is better to set proper voltages using the sketch or via LCD and buttons.
 
 * Added the option for LCD daytime on (LCD on when sunlight is detected and charging starts. LCD turns off when the sun is down.) I also removed some LCD sleep timer setting.
+
+* Reduced Temperature Sensor Average Sampling Count for faster temperature sensor

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This is a clone from https://github.com/AngeloCasi/FUGU-ARDUINO-MPPT-FIRMWARE.gi
 I have modified the firmware and published here for anyone to use.
 
 Changelog:
+
 Initial release Oct. 22, 2022
 * set ADS1115 as default parameter (ADS1115 is actually cheaper now and easier to buy than ADS1015) NOTE: Change the values if you are using ADS1015
 


### PR DESCRIPTION
* Removed buttons to adjust battery charging voltage settings in Blynk app. This feature seems dangerous and can accidentally set the charging voltage too high because of the terrible input lag. It is better to set proper voltages using the sketch or via LCD and buttons.

* Added the option for LCD daytime on (LCD on when sunlight is detected and charging starts. LCD turns off when the sun is down.) I also removed some LCD sleep timer setting.

* Reduced Temperature Sensor Average Sampling Count for faster temperature sensor